### PR TITLE
nk: small fix for when using invalid args

### DIFF
--- a/nk/main.go
+++ b/nk/main.go
@@ -126,20 +126,26 @@ func verify(fname, keyFile, pubFile, sigFile string) {
 	if sigFile == "" {
 		log.Fatalf("Verify requires a signature via -sigfile")
 	}
+	var err error
 	var kp nkeys.KeyPair
 	if keyFile != "" {
-		seed, err := ioutil.ReadFile(keyFile)
+		var seed []byte
+		seed, err = ioutil.ReadFile(keyFile)
 		if err != nil {
 			log.Fatal(err)
 		}
 		kp, err = nkeys.FromSeed(string(seed))
 	} else {
 		// Public Key
-		public, err := ioutil.ReadFile(pubFile)
+		var public []byte
+		public, err = ioutil.ReadFile(pubFile)
 		if err != nil {
 			log.Fatal(err)
 		}
 		kp, err = nkeys.FromPublicKey(string(public))
+	}
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	content, err := ioutil.ReadFile(fname)


### PR DESCRIPTION
Error was becoming shadowed and causing panic when using wrong arg accidentally:

```sh
nk -verify example.txt -sigfile example.sig -inkey user.seed
verification succeeded

nk -verify example.txt -sigfile example.sig -pubin user.seed # <-- last arg should have been user.pub
panic: runtime error: invalid memory address or nil pointer dereference
...
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>