### PR TITLE
Remove strings

### DIFF
--- a/keypair.go
+++ b/keypair.go
@@ -23,7 +23,7 @@ import (
 
 // kp is the internal struct for a kepypair using seed.
 type kp struct {
-	seed string
+	seed []byte
 }
 
 // createPair will create a KeyPair based on the rand entropy and a type/prefix byte. rand can be nil.
@@ -57,30 +57,36 @@ func (pair *kp) keys() (ed25519.PublicKey, ed25519.PrivateKey, error) {
 	return ed25519.GenerateKey(bytes.NewReader(raw))
 }
 
+// Wipe will randomize the contents of the seed key
+func (pair *kp) Wipe() {
+	io.ReadFull(rand.Reader, pair.seed)
+	pair.seed = nil
+}
+
 // Seed will return the encoded seed.
-func (pair *kp) Seed() (string, error) {
+func (pair *kp) Seed() ([]byte, error) {
 	return pair.seed, nil
 }
 
 // PublicKey will return the encoded public key associated with the KeyPair.
 // All KeyPairs have a public key.
-func (pair *kp) PublicKey() (string, error) {
+func (pair *kp) PublicKey() ([]byte, error) {
 	public, raw, err := DecodeSeed(pair.seed)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	pub, _, err := ed25519.GenerateKey(bytes.NewReader(raw))
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	return Encode(public, pub)
 }
 
 // PrivateKey will return the encoded private key for KeyPair.
-func (pair *kp) PrivateKey() (string, error) {
+func (pair *kp) PrivateKey() ([]byte, error) {
 	_, priv, err := pair.keys()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	return Encode(PrefixBytePrivate, priv)
 }

--- a/main.go
+++ b/main.go
@@ -34,11 +34,12 @@ var (
 
 // KeyPair provides the central interface to nkeys.
 type KeyPair interface {
-	Seed() (string, error)
-	PublicKey() (string, error)
-	PrivateKey() (string, error)
+	Seed() ([]byte, error)
+	PublicKey() ([]byte, error)
+	PrivateKey() ([]byte, error)
 	Sign(input []byte) ([]byte, error)
 	Verify(input []byte, sig []byte) error
+	Wipe()
 }
 
 // CreateUser will create a User typed KeyPair.
@@ -67,7 +68,7 @@ func CreateOperator() (KeyPair, error) {
 }
 
 // FromPublicKey will create a KeyPair capable of verifying signatures.
-func FromPublicKey(public string) (KeyPair, error) {
+func FromPublicKey(public []byte) (KeyPair, error) {
 	raw, err := decode(public)
 	if err != nil {
 		return nil, err
@@ -80,7 +81,7 @@ func FromPublicKey(public string) (KeyPair, error) {
 }
 
 // FromSeed will create a KeyPair capable of signing and verifying signatures.
-func FromSeed(seed string) (KeyPair, error) {
+func FromSeed(seed []byte) (KeyPair, error) {
 	_, _, err := DecodeSeed(seed)
 	if err != nil {
 		return nil, err

--- a/nk/main.go
+++ b/nk/main.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/base32"
 	"encoding/base64"
@@ -47,7 +48,6 @@ func main() {
 
 	var keyType = flag.String("gen", "", "Generate key for <type>, e.g. nk -gen user")
 	var pubout = flag.Bool("pubout", false, "Output public key")
-
 
 	var version = flag.Bool("v", false, "Show version")
 	var vanPre = flag.String("pre", "", "Attempt to generate public key given prefix, e.g. nk -gen user -pre derek")
@@ -115,7 +115,7 @@ func printPublicFromSeed(keyFile string) {
 		log.Fatal(err)
 	}
 
-	kp, err := nkeys.FromSeed(string(seed))
+	kp, err := nkeys.FromSeed(seed)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -132,7 +132,7 @@ func sign(fname, keyFile string) {
 		log.Fatal(err)
 	}
 
-	kp, err := nkeys.FromSeed(string(seed))
+	kp, err := nkeys.FromSeed(seed)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -164,7 +164,7 @@ func verify(fname, keyFile, pubFile, sigFile string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		kp, err = nkeys.FromSeed(string(seed))
+		kp, err = nkeys.FromSeed(seed)
 	} else {
 		// Public Key
 		var public []byte
@@ -172,7 +172,7 @@ func verify(fname, keyFile, pubFile, sigFile string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		kp, err = nkeys.FromPublicKey(string(public))
+		kp, err = nkeys.FromPublicKey(public)
 	}
 	if err != nil {
 		log.Fatal(err)
@@ -257,7 +257,7 @@ func createVanityKey(keyType, vanity, entropy string, max int) nkeys.KeyPair {
 		fmt.Fprintf(os.Stderr, "\r\033[mcomputing\033[m %s ", string(spin))
 		kp := genKeyPair(pre, entropy)
 		pub, _ := kp.PublicKey()
-		if strings.HasPrefix(pub[1:], vanity) {
+		if bytes.HasPrefix(pub[1:], []byte(vanity)) {
 			fmt.Fprintf(os.Stderr, "\r")
 			return kp
 		}

--- a/public.go
+++ b/public.go
@@ -14,6 +14,9 @@
 package nkeys
 
 import (
+	"crypto/rand"
+	"io"
+
 	"golang.org/x/crypto/ed25519"
 )
 
@@ -25,18 +28,18 @@ type pub struct {
 
 // PublicKey will return the encoded public key associated with the KeyPair.
 // All KeyPairs have a public key.
-func (p *pub) PublicKey() (string, error) {
+func (p *pub) PublicKey() ([]byte, error) {
 	return Encode(p.pre, p.pub)
 }
 
 // Seed will return an error since this is not available for public key only KeyPairs.
-func (p *pub) Seed() (string, error) {
-	return "", ErrPublicKeyOnly
+func (p *pub) Seed() ([]byte, error) {
+	return nil, ErrPublicKeyOnly
 }
 
 // PrivateKey will return an error since this is not available for public key only KeyPairs.
-func (p *pub) PrivateKey() (string, error) {
-	return "", ErrPublicKeyOnly
+func (p *pub) PrivateKey() ([]byte, error) {
+	return nil, ErrPublicKeyOnly
 }
 
 // Sign will return an error since this is not available for public key only KeyPairs.
@@ -50,4 +53,10 @@ func (p *pub) Verify(input []byte, sig []byte) error {
 		return ErrInvalidSignature
 	}
 	return nil
+}
+
+// Wipe will randomize the public key and erase the pre byte.
+func (p *pub) Wipe() {
+	p.pre = '0'
+	io.ReadFull(rand.Reader, p.pub)
 }

--- a/strkey.go
+++ b/strkey.go
@@ -51,40 +51,43 @@ const (
 var b32Enc = base32.StdEncoding.WithPadding(base32.NoPadding)
 
 // Encode will encode a raw key or seed with the prefix and crc16 and then base32 encoded.
-func Encode(prefix PrefixByte, src []byte) (string, error) {
+func Encode(prefix PrefixByte, src []byte) ([]byte, error) {
 	if err := checkValidPrefixByte(prefix); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	var raw bytes.Buffer
 
 	// write prefix byte
 	if err := raw.WriteByte(byte(prefix)); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// write payload
 	if _, err := raw.Write(src); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// Calculate and write crc16 checksum
 	err := binary.Write(&raw, binary.LittleEndian, crc16(raw.Bytes()))
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return b32Enc.EncodeToString(raw.Bytes()), nil
+	data := raw.Bytes()
+	buf := make([]byte, b32Enc.EncodedLen(len(data)))
+	b32Enc.Encode(buf, data)
+	return buf[:], nil
 }
 
 // EncodeSeed will encode a raw key with the prefix and then seed prefix and crc16 and then base32 encoded.
-func EncodeSeed(public PrefixByte, src []byte) (string, error) {
+func EncodeSeed(public PrefixByte, src []byte) ([]byte, error) {
 	if err := checkValidPublicPrefixByte(public); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	if len(src) != ed25519.SeedSize {
-		return "", ErrInvalidSeedLen
+		return nil, ErrInvalidSeedLen
 	}
 
 	// In order to make this human printable for both bytes, we need to do a little
@@ -99,24 +102,29 @@ func EncodeSeed(public PrefixByte, src []byte) (string, error) {
 
 	// write payload
 	if _, err := raw.Write(src); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// Calculate and write crc16 checksum
 	err := binary.Write(&raw, binary.LittleEndian, crc16(raw.Bytes()))
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return b32Enc.EncodeToString(raw.Bytes()), nil
+	data := raw.Bytes()
+	buf := make([]byte, b32Enc.EncodedLen(len(data)))
+	b32Enc.Encode(buf, data)
+	return buf, nil
 }
 
-// decode will decode the base32 string and check crc16 and the prefix for validity.
-func decode(src string) ([]byte, error) {
-	raw, err := b32Enc.DecodeString(src)
+// decode will decode the base32 and check crc16 and the prefix for validity.
+func decode(src []byte) ([]byte, error) {
+	raw := make([]byte, b32Enc.EncodedLen(len(src)))
+	n, err := b32Enc.Decode(raw, src)
 	if err != nil {
 		return nil, err
 	}
+	raw = raw[:n]
 
 	if len(raw) < 4 {
 		return nil, ErrInvalidEncoding
@@ -133,11 +141,11 @@ func decode(src string) ([]byte, error) {
 		return nil, err
 	}
 
-	return raw[0 : len(raw)-2], nil
+	return raw[:len(raw)-2], nil
 }
 
 // Decode will decode the base32 string and check crc16 and enforce the prefix is what is expected.
-func Decode(expectedPrefix PrefixByte, src string) ([]byte, error) {
+func Decode(expectedPrefix PrefixByte, src []byte) ([]byte, error) {
 	if err := checkValidPrefixByte(expectedPrefix); err != nil {
 		return nil, err
 	}
@@ -155,7 +163,7 @@ func Decode(expectedPrefix PrefixByte, src string) ([]byte, error) {
 
 // DecodeSeed will decode the base32 string and check crc16 and enforce the prefix is a seed
 // and the subsequent type is a valid type.
-func DecodeSeed(src string) (PrefixByte, []byte, error) {
+func DecodeSeed(src []byte) (PrefixByte, []byte, error) {
 	raw, err := decode(src)
 	if err != nil {
 		return PrefixByteSeed, nil, err
@@ -174,31 +182,31 @@ func DecodeSeed(src string) (PrefixByte, []byte, error) {
 }
 
 // IsValidPublicUserKey will decode and verify the string is a valid encoded Public User Key.
-func IsValidPublicUserKey(src string) bool {
+func IsValidPublicUserKey(src []byte) bool {
 	_, err := Decode(PrefixByteUser, src)
 	return err == nil
 }
 
 // IsValidPublicAccountKey will decode and verify the string is a valid encoded Public Account Key.
-func IsValidPublicAccountKey(src string) bool {
+func IsValidPublicAccountKey(src []byte) bool {
 	_, err := Decode(PrefixByteAccount, src)
 	return err == nil
 }
 
 // IsValidPublicServerKey will decode and verify the string is a valid encoded Public Server Key.
-func IsValidPublicServerKey(src string) bool {
+func IsValidPublicServerKey(src []byte) bool {
 	_, err := Decode(PrefixByteServer, src)
 	return err == nil
 }
 
 // IsValidPublicClusterKey will decode and verify the string is a valid encoded Public Cluster Key.
-func IsValidPublicClusterKey(src string) bool {
+func IsValidPublicClusterKey(src []byte) bool {
 	_, err := Decode(PrefixByteCluster, src)
 	return err == nil
 }
 
 // IsValidPublicOperatorKey will decode and verify the string is a valid encoded Public Operator Key.
-func IsValidPublicOperatorKey(src string) bool {
+func IsValidPublicOperatorKey(src []byte) bool {
 	_, err := Decode(PrefixByteOperator, src)
 	return err == nil
 }


### PR DESCRIPTION
Golang treats strings as read only. Convert all of our handing of private keys to []byte and offer option to wipe the memory we referenced.

Signed-off-by: Derek Collison <derek@nats.io>