### PR TITLE
Fix go-lint warnings and PrefixByteUnknown typo.

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 )
 
-// Version
+// Version is our current version
 const Version = "0.0.2"
 
 // Errors
@@ -93,7 +93,7 @@ func FromSeed(seed []byte) (KeyPair, error) {
 	return &kp{copy}, nil
 }
 
-// Create a KeyPair from the raw 32 byte seed for a given type.
+// FromRawSeed will create a KeyPair from the raw 32 byte seed for a given type.
 func FromRawSeed(prefix PrefixByte, rawSeed []byte) (KeyPair, error) {
 	seed, err := EncodeSeed(prefix, rawSeed)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -266,8 +266,8 @@ func TestPrefixByte(t *testing.T) {
 	if pre := Prefix(string(seed)); pre != PrefixByteSeed {
 		t.Fatalf("Expected %s, got %s\n", PrefixByteSeed, pre)
 	}
-	if pre := Prefix("SEED"); pre != PrefixByteUknown {
-		t.Fatalf("Expected %s, got %s\n", PrefixByteUknown, pre)
+	if pre := Prefix("SEED"); pre != PrefixByteUnknown {
+		t.Fatalf("Expected %s, got %s\n", PrefixByteUnknown, pre)
 	}
 	account, _ := CreateAccount()
 	pub, _ = account.PublicKey()

--- a/strkey.go
+++ b/strkey.go
@@ -47,7 +47,7 @@ const (
 	PrefixByteUser PrefixByte = 20 << 3 // Base32-encodes to 'U...'
 
 	// PrefixByteUnknown is for unknown prefixes.
-	PrefixByteUknown PrefixByte = 23 << 3 // Base32-encodes to 'X...'
+	PrefixByteUnknown PrefixByte = 23 << 3 // Base32-encodes to 'X...'
 )
 
 // Set our encoding to not include padding '=='
@@ -188,10 +188,11 @@ func DecodeSeed(src []byte) (PrefixByte, []byte, error) {
 	return PrefixByte(b2), raw[2:], nil
 }
 
+// Prefix returns PrefixBytes of its input
 func Prefix(src string) PrefixByte {
 	b, err := decode([]byte(src))
 	if err != nil {
-		return PrefixByteUknown
+		return PrefixByteUnknown
 	}
 	prefix := PrefixByte(b[0])
 	err = checkValidPrefixByte(prefix)
@@ -203,7 +204,7 @@ func Prefix(src string) PrefixByte {
 	if PrefixByte(b1) == PrefixByteSeed {
 		return PrefixByteSeed
 	}
-	return PrefixByteUknown
+	return PrefixByteUnknown
 }
 
 // IsValidPublicKey will decode and verify that the string is a valid encoded public key.


### PR DESCRIPTION
commit f897943c6d2342cf305b0b383b940e6a191e632f
Author: Harrison Chienjo <hhathersage@gmail.com>
Date:   Fri Dec 14 17:45:02 2018 +0300

    Fix go-lint warnings.

commit 5498296553c33df06b203703f39d61b844d0dce6
Author: Harrison Chienjo <hhathersage@gmail.com>
Date:   Fri Dec 14 17:39:29 2018 +0300

    Fix constant PrefixByteUnknown typo.