### PR TITLE
Added ability to extract the role of a KeyPair and to validate the roles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/nats-io/nkeys
 
 require golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
+
+go 1.13

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Version is our current version
-const Version = "0.1.0"
+const Version = "0.1.2"
 
 // Errors
 var (
@@ -33,6 +33,7 @@ var (
 	ErrInvalidSignature  = errors.New("nkeys: signature verification failed")
 	ErrCannotSign        = errors.New("nkeys: can not sign, no private key available")
 	ErrPublicKeyOnly     = errors.New("nkeys: no seed or private key available")
+	ErrIncompatibleKey   = errors.New("nkeys: incompatible key")
 )
 
 // KeyPair provides the central interface to nkeys.

--- a/strkey.go
+++ b/strkey.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"encoding/base32"
 	"encoding/binary"
-
 	"golang.org/x/crypto/ed25519"
 )
 
@@ -288,4 +287,21 @@ func (p PrefixByte) String() string {
 		return "private"
 	}
 	return "unknown"
+}
+
+
+// CompatibleKeyPair returns an error if the KeyPair doesn't match expected PrefixByte(s)
+func CompatibleKeyPair(kp KeyPair, expected ...PrefixByte) error {
+	pk, err := kp.PublicKey()
+	if err != nil {
+		return err
+	}
+	pkType := Prefix(pk)
+	for _, k := range expected {
+		if pkType == k {
+			return nil
+		}
+	}
+
+	return ErrIncompatibleKey
 }


### PR DESCRIPTION
Currently extracting the prefix of a keypair requires doing a number of api calls. Validating such prefixes against client code require prefixes also requires a bit of code that should be part of the library.
