### PR TITLE
Release v0.1.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/nats-io/nkeys
 
 require golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
-
-go 1.13

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Version is our current version
-const Version = "0.1.2"
+const Version = "0.1.3"
 
 // Errors
 var (

--- a/main_test.go
+++ b/main_test.go
@@ -18,6 +18,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"io"
+	"os"
 	"regexp"
 	"testing"
 
@@ -29,6 +30,23 @@ func TestVersion(t *testing.T) {
 	verRe := regexp.MustCompile(`\d+.\d+.\d+(-\S+)?`)
 	if !verRe.MatchString(Version) {
 		t.Fatalf("Version not compatible with semantic versioning: %q", Version)
+	}
+}
+
+func TestVersionMatchesTag(t *testing.T) {
+	tag := os.Getenv("TRAVIS_TAG")
+	if tag == "" {
+		t.SkipNow()
+	}
+	// We expect a tag of the form vX.Y.Z. If that's not the case,
+	// we need someone to have a look. So fail if first letter is not
+	// a `v`
+	if tag[0] != 'v' {
+		t.Fatalf("Expect tag to start with `v`, tag is: %s", tag)
+	}
+	// Strip the `v` from the tag for the version comparison.
+	if Version != tag[1:] {
+		t.Fatalf("Version (%s) does not match tag (%s)", Version, tag[1:])
 	}
 }
 


### PR DESCRIPTION
This is to fix the "moved" v0.1.2 tag.

Resolves #21

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>