### PR TITLE
Exported NKeys Error Enhancement

### DIFF
--- a/crc16.go
+++ b/crc16.go
@@ -13,14 +13,7 @@
 
 package nkeys
 
-import (
-	"errors"
-)
-
 // An implementation of crc16 according to CCITT standards for XMODEM.
-
-// ErrInvalidChecksum indicates a failed verification.
-var ErrInvalidChecksum = errors.New("nkeys: invalid checksum")
 
 var crc16tab = [256]uint16{
 	0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7,

--- a/creds_utils.go
+++ b/creds_utils.go
@@ -2,7 +2,6 @@ package nkeys
 
 import (
 	"bytes"
-	"errors"
 	"regexp"
 )
 
@@ -42,12 +41,12 @@ func ParseDecoratedNKey(contents []byte) (KeyPair, error) {
 		}
 	}
 	if seed == nil {
-		return nil, errors.New("no nkey seed found")
+		return nil, ErrNoSeedFound
 	}
 	if !bytes.HasPrefix(seed, []byte("SO")) &&
 		!bytes.HasPrefix(seed, []byte("SA")) &&
 		!bytes.HasPrefix(seed, []byte("SU")) {
-		return nil, errors.New("doesn't contain a seed nkey")
+		return nil, ErrInvalidNkeySeed
 	}
 	kp, err := FromSeed(seed)
 	if err != nil {
@@ -68,7 +67,7 @@ func ParseDecoratedUserNKey(contents []byte) (KeyPair, error) {
 		return nil, err
 	}
 	if !bytes.HasPrefix(seed, []byte("SU")) {
-		return nil, errors.New("doesn't contain an user seed nkey")
+		return nil, ErrInvalidUserSeed
 	}
 	kp, err := FromSeed(seed)
 	if err != nil {

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,38 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nkeys
+
+// Errors
+const (
+	ErrInvalidPrefixByte = nkeysError("nkeys: invalid prefix byte")
+	ErrInvalidKey        = nkeysError("nkeys: invalid key")
+	ErrInvalidPublicKey  = nkeysError("nkeys: invalid public key")
+	ErrInvalidSeedLen    = nkeysError("nkeys: invalid seed length")
+	ErrInvalidSeed       = nkeysError("nkeys: invalid seed")
+	ErrInvalidEncoding   = nkeysError("nkeys: invalid encoded key")
+	ErrInvalidSignature  = nkeysError("nkeys: signature verification failed")
+	ErrCannotSign        = nkeysError("nkeys: can not sign, no private key available")
+	ErrPublicKeyOnly     = nkeysError("nkeys: no seed or private key available")
+	ErrIncompatibleKey   = nkeysError("nkeys: incompatible key")
+	ErrInvalidChecksum   = nkeysError("nkeys: invalid checksum")
+	ErrNoSeedFound       = nkeysError("no nkey seed found")
+	ErrInvalidNkeySeed   = nkeysError("doesn't contain a seed nkey")
+	ErrInvalidUserSeed   = nkeysError("doesn't contain an user seed nkey")
+)
+
+type nkeysError string
+
+func (e nkeysError) Error() string {
+	return string(e)
+}

--- a/main.go
+++ b/main.go
@@ -15,26 +15,8 @@
 // and performs signing and verification.
 package nkeys
 
-import (
-	"errors"
-)
-
 // Version is our current version
 const Version = "0.3.0"
-
-// Errors
-var (
-	ErrInvalidPrefixByte = errors.New("nkeys: invalid prefix byte")
-	ErrInvalidKey        = errors.New("nkeys: invalid key")
-	ErrInvalidPublicKey  = errors.New("nkeys: invalid public key")
-	ErrInvalidSeedLen    = errors.New("nkeys: invalid seed length")
-	ErrInvalidSeed       = errors.New("nkeys: invalid seed")
-	ErrInvalidEncoding   = errors.New("nkeys: invalid encoded key")
-	ErrInvalidSignature  = errors.New("nkeys: signature verification failed")
-	ErrCannotSign        = errors.New("nkeys: can not sign, no private key available")
-	ErrPublicKeyOnly     = errors.New("nkeys: no seed or private key available")
-	ErrIncompatibleKey   = errors.New("nkeys: incompatible key")
-)
 
 // KeyPair provides the central interface to nkeys.
 type KeyPair interface {


### PR DESCRIPTION
Make the errors exported outside const instead variable, so that the
users can not change them, and do cleanup to the others return errors
not defined clearly.

Signed-off-by: JUN JIE NAN <nanjunjie@gmail.com>