### PR TITLE
Trim whitespace from the parsed JWT

### DIFF
--- a/creds_utils.go
+++ b/creds_utils.go
@@ -3,6 +3,7 @@ package nkeys
 import (
 	"bytes"
 	"regexp"
+	"strings"
 )
 
 var userConfigRE = regexp.MustCompile(`\s*(?:(?:[-]{3,}.*[-]{3,}\r?\n)([\w\-.=]+)(?:\r?\n[-]{3,}.*[-]{3,}\r?\n))`)
@@ -18,7 +19,7 @@ func ParseDecoratedJWT(contents []byte) (string, error) {
 	raw := items[0][1]
 	tmp := make([]byte, len(raw))
 	copy(tmp, raw)
-	return string(tmp), nil
+	return strings.TrimSpace(string(tmp)), nil
 }
 
 // ParseDecoratedNKey takes a creds file, finds the NKey portion and creates a


### PR DESCRIPTION
Since the JWT is read from a file that may be produced programmatically
(in one form or another), it is possible for there to be one or more
additional whitespace surrounding the JWT in the decorated file. This
simply ensure the whitespace is trimmed as is performed when parsing the
seed value.

Signed-off-by: Byron Ruth <b@devel.io>