### PR TITLE
CI: bump staticcheck GHAction

### DIFF
--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -66,7 +66,7 @@ jobs:
         # You can see the individual values in the "Set up Go" output, collapsed inside a "go env" group at the end.
 
       - name: Install staticcheck
-        uses: dominikh/staticcheck-action@v1.2.0
+        uses: dominikh/staticcheck-action@v1.3.0
         with:
           version: "2022.1.1"
 


### PR DESCRIPTION
For initial setup, I used the docs at <https://staticcheck.io/docs/running-staticcheck/ci/github-actions/> which worked, but we noticed slightly late that there were deprecation warnings on our shiny new GitHub Action.  
Meanwhile, <https://github.com/marketplace/actions/staticcheck> has a newer version of the action.

So bump the staticcheck action version (not the staticcheck binary version).
