### PR TITLE
Update README.md

### DIFF
--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -15,6 +15,8 @@ permissions:
 
 on:
   push:
+    paths-ignore:
+      - "**/*.md"
     branches-ignore:
       - 'exp'
       - 'exp/*'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,8 @@ on:
   push:
     tags:
       - 'v[0-9]*'
+    paths-ignore:
+      - "**/*.md"
 
 permissions:
   # Control the GITHUB_TOKEN permissions; GitHub's docs on which permission scopes control what are a little lacking.
@@ -55,4 +57,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/nk/README.md
+++ b/nk/README.md
@@ -2,31 +2,34 @@
 
 [![License Apache 2](https://img.shields.io/badge/License-Apache2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
-## SYNOPSIS
-
-```bash
-nk [-gen type] [-sign file] [-verify file] [-inkey keyfile] [-pubin keyfile] [-pubout] [-e entropy]
-```
-
 ## DESCRIPTION
 
 The nk utility program can be used to generate nkeys, signing, and verify signatures.
 
+## INSTALLATION
+
+```bash
+go install github.com/nats-io/nkeys/nk@latest
+```
+
 ## COMMAND OPTIONS
 
--gen type
+```
+Usage: nk [options]
+    -v                    Show version
+    -gen <type>           Generate key for [user|account|server|cluster|operator|curve|x25519]
+    -sign <file>          Sign <file> with -inkey <keyfile>
+    -verify <file>        Verfify <file> with -inkey <keyfile> or -pubin <public> and -sigfile <file>
+    -inkey <file>         Input key file (seed/private key)
+    -pubin <file>         Public key file
+    -sigfile <file>       Signature file
+    -pubout               Output public key
+    -e                    Entropy file, e.g. /dev/urandom
+    -pre <vanity>         Attempt to generate public key given prefix, e.g. nk -gen user -pre derek
+    -maxpre <N>           Maximum attempts at generating the correct key prefix, default is 10,000,000
+```
 
-Used to create an Nkey Seed of a given type. Type can be **User**, **Account**, **Server**, **Cluster**, or **Operator**
-
--sign file
-
-Used to sign the contents of file. -inkey is also required.
-
--verify file -sigfile sig
-
-Used to verify a file with a given signature. -inkey or -pubin also required.
-
-## Examples
+## EXAMPLES
 
 Create a user keypair. The result will be an encoded seed. Seeds are prefixed with an 'S', and followed by the type, e.g. U = user.
 
@@ -65,7 +68,7 @@ Verified OK
 Verified OK
 ```
 
-## License
+## LICENSE
 
 Unless otherwise noted, the NATS source files are distributed
 under the Apache Version 2.0 license found in the LICENSE file.


### PR DESCRIPTION
- adding install command for quick copy
- some cli options were missing. instead of breaking the `SYNOPSIS` line, I copied the output of `nk` to `COMMAND OPTIONS`
- make remaining lvl 2 headlines all-caps for consistency
- ignoring `**/*.md` for GitHub actions