### PR TITLE
fix: rename Version to version

### DIFF
--- a/nk/main.go
+++ b/nk/main.go
@@ -29,7 +29,7 @@ import (
 )
 
 // this will be set during compilation when a release is made on tools
-var Version string
+var version string
 
 const defaultVanMax = 10_000_000
 
@@ -67,7 +67,7 @@ func main() {
 	var keyType = flag.String("gen", "", "Generate key for <type>, e.g. nk -gen user")
 	var pubout = flag.Bool("pubout", false, "Output public key")
 
-	var version = flag.Bool("v", false, "Show version")
+	var versionFlag = flag.Bool("v", false, "Show version")
 	var vanPre = flag.String("pre", "", "Attempt to generate public key given prefix, e.g. nk -gen user -pre derek")
 	var vanMax = flag.Int("maxpre", defaultVanMax, "Maximum attempts at generating the correct key prefix")
 
@@ -77,8 +77,8 @@ func main() {
 	flag.Usage = usage
 	flag.Parse()
 
-	if *version {
-		fmt.Printf("nk version %s\n", Version)
+	if *versionFlag {
+		fmt.Printf("nk version %s\n", version)
 		return
 	}
 


### PR DESCRIPTION
Tested locally with

```bash
> go build -ldflags="-X main.Version=v0.4.8" -o nkTest ./nk
> ./nkTest
nk version
> go build -ldflags="-X main.version=v0.4.8" -o nkTest ./nk
> ./nkTest
nk version v0.4.8
```

since according to the docs https://goreleaser.com/cookbooks/using-main.version/ the version is set with a lowercase `v` I assume this will work in the pipeline