### PR TITLE
Custom `PrefixByte` Support

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -16,6 +16,7 @@ package nkeys
 // Errors
 const (
 	ErrInvalidPrefixByte        = nkeysError("nkeys: invalid prefix byte")
+	ErrDuplicatePrefixByte      = nkeysError("nkeys: prefix byte already present")
 	ErrInvalidKey               = nkeysError("nkeys: invalid key")
 	ErrInvalidPublicKey         = nkeysError("nkeys: invalid public key")
 	ErrInvalidPrivateKey        = nkeysError("nkeys: invalid private key")

--- a/nkeys_test.go
+++ b/nkeys_test.go
@@ -659,7 +659,7 @@ func TestValidateKeyPairRole(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var keyroles = []struct {
+	keyroles := []struct {
 		kp    KeyPair
 		roles []PrefixByte
 		ok    bool
@@ -685,7 +685,6 @@ func TestValidateKeyPairRole(t *testing.T) {
 		}
 		if err != nil && e.ok {
 			t.Fatalf("test %q should have not failed: %v", e.name, err)
-
 		}
 		if err != nil && !e.ok && err != ErrIncompatibleKey {
 			t.Fatalf("unexpected error type for %q: %v", e.name, err)
@@ -728,4 +727,20 @@ func TestSealOpen(t *testing.T) {
 	testSealOpen(t, PrefixByteOperator)
 	testSealOpen(t, PrefixByteAccount)
 	testSealOpen(t, PrefixByteUser)
+}
+
+func TestCustomPublicPrefix(t *testing.T) {
+	var prefixModule PrefixByte = 12 << 3 // Base32-encodes to 'M...'
+	AddPublicPrefix(prefixModule, "module")
+	testSealOpen(t, prefixModule)
+
+	if v := prefixModule.String(); v != "module" {
+		t.Fatalf("Expected 'module', got %v", v)
+	}
+
+	RemovePublicPrefix(prefixModule)
+
+	if v := prefixModule.String(); v != "unknown" {
+		t.Fatalf("Expected 'unknown', got %v", v)
+	}
 }


### PR DESCRIPTION
Allow programs to introduce their own prefixes, avoiding collision with known prefixes.
Scenario: Signing binary 'modules' using pub keys prefixed with `M`.

```
var modulePrefix PrefixByte = 12 << 3 // Base32-encodes to 'M...'

// register new prefix
nkeys.AddPublicPrefix(modulePrefix, "module")

// creating a new pair
moduleKey, _ := CreatePair(modulePrefix)

// prefix name Stringer returns 'module' instead of 'unknown'
modulePrefix.String()

// use .PrivateKey(), .PublicKey(), .Sign(), .Verify() as usual
```

The resulting data looks like:
```
Seed SMAPILBZ447DMKKISBEUPTV4M6OMLGPSGSZDWEYRDH3OPSCFW2HG5H5CNQ
Pub MDDWNXZNY4OM2EFCQO7MOPOS4SGHOVBNV5GZ53T3LWHMHRSN5VFDFN6Y
Private PD2CYOPHHY3CSSEQJFD45PDHTTCZT4RUWI5RGEIZ63T4QRNWRZXJ7R3G34W4OHGNCCRIHPWHHXJOJDDXKQW26TM65Z5V3DWDYZG62SRSHSQQ
```