### PR TITLE
various changes to enable MS FIPS tests

### DIFF
--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -33,19 +33,16 @@ jobs:
     strategy:
       matrix:
         include:
-          - go: '1.21.x'
+          - go: stable
             os: ubuntu-latest
             canonical: true
-          - go: '1.20.x'
-            os: ubuntu-latest
-            canonical: false
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
           # We're not doing releases, just checks, so we can live without check-latest here
@@ -66,9 +63,9 @@ jobs:
         # You can see the individual values in the "Set up Go" output, collapsed inside a "go env" group at the end.
 
       - name: Install staticcheck
-        uses: dominikh/staticcheck-action@v1.3.0
+        uses: dominikh/staticcheck-action@v1.3.1
         with:
-          version: "2022.1.1"
+          version: "2024.1.1"
 
       - name: Install additional check/lint tools
         id: tools-install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # NB: the `fetch-depth: 0` setting is documented by goreleaser
           # as a requirement, for the changelog feature to work correctly.
@@ -34,9 +34,9 @@ jobs:
       #  docker/setup-buildx-action@v1
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: stable
           check-latest: true
 
       - name: Basic integrity checks
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run GoReleaser
         id: goreleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v6
         with:
           args: release --clean
         env:

--- a/nkeys_test.go
+++ b/nkeys_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The NATS Authors
+// Copyright 2018-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,14 +15,13 @@ package nkeys
 
 import (
 	"bytes"
+	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base64"
 	"io"
 	"os"
 	"regexp"
 	"testing"
-
-	"golang.org/x/crypto/ed25519"
 )
 
 func TestVersion(t *testing.T) {

--- a/public.go
+++ b/public.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The NATS Authors
+// Copyright 2018-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,10 +14,9 @@
 package nkeys
 
 import (
+	"crypto/ed25519"
 	"crypto/rand"
 	"io"
-
-	"golang.org/x/crypto/ed25519"
 )
 
 // A KeyPair from a public key capable of verifying only.

--- a/xkeys.go
+++ b/xkeys.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The NATS Authors
+// Copyright 2022-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,6 +15,7 @@ package nkeys
 
 import (
 	"bytes"
+	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/binary"
 	"io"
@@ -40,17 +41,18 @@ type ckp struct {
 
 // CreateCurveKeys will create a Curve typed KeyPair.
 func CreateCurveKeys() (KeyPair, error) {
-	return CreateCurveKeysWithRand(rand.Reader)
+	return CreateCurveKeysWithRand(nil)
 }
 
 // CreateCurveKeysWithRand will create a Curve typed KeyPair
 // with specified rand source.
 func CreateCurveKeysWithRand(rr io.Reader) (KeyPair, error) {
 	var kp ckp
-	_, err := io.ReadFull(rr, kp.seed[:])
+	_, priv, err := ed25519.GenerateKey(rr)
 	if err != nil {
 		return nil, err
 	}
+	kp.seed = [curveKeyLen]byte(priv.Seed())
 	return &kp, nil
 }
 


### PR DESCRIPTION
change: from "golang.org/x/crypto/ed25519" to "crypto/ed25519"

change: when creating private key is to NOT provide a rand.Reader, and allow ed25519.GenerateKey() decide what reader to use, this enables and fixes #67

Other changes suggested by #67 change the structure of the library in more aggressive ways - currently, the private key is encoded into its NATS seed format in `kp`. Storing the private key, and prefix instead to enable extracting and formatting the seed, etc, means that all the size and format checks would have to cascade to various APIs.