### PR TITLE
Add 'go mod tidy' to release workflow integrity checks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Basic integrity checks
         run: |
+          go mod tidy
           go vet ./...
           out="$(go list -m -retracted -f '{{if .Retracted}}{{.Path}} is retracted{{end}}' all)"
           if [ -n "$out" ]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Basic integrity checks
         run: |
-          go mod tidy
+          go mod tidy -diff
           go vet ./...
           out="$(go list -m -retracted -f '{{if .Retracted}}{{.Path}} is retracted{{end}}' all)"
           if [ -n "$out" ]; then


### PR DESCRIPTION
This ensures that the module dependencies are cleaned up and consistent before running checks. It helps prevent issues related to unused or incorrect dependencies in the build process.