### PR TITLE
bump deps/fix release script

### DIFF
--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
           # We're not doing releases, just checks, so we can live without check-latest here

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
       #  docker/setup-buildx-action@v1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
           check-latest: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,6 @@ jobs:
 
       - name: Basic integrity checks
         run: |
-          go mod tidy -diff
           go vet ./...
           out="$(go list -m -retracted -f '{{if .Retracted}}{{.Path}} is retracted{{end}}' all)"
           if [ -n "$out" ]; then

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/nats-io/nkeys
 
 go 1.24.0
 
-require golang.org/x/crypto v0.45.0
+require golang.org/x/crypto v0.47.0
 
-require golang.org/x/sys v0.38.0 // indirect
+require golang.org/x/sys v0.40.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
-golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
-golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
-golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
+golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
+golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
+golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
chore(deps): update golang.org/x/crypto to v0.47.0 and golang.org/x/sys to v0.40.0

fix: release action was doing a go mod tidy -diff which interfered with go toolchain failing it with `go: updates to go.sum needed, disabled by -mod=readonly` - this is not needed